### PR TITLE
adding chip label column to awk output

### DIFF
--- a/Imp_Scripts/DiffAnalysisHiChIP.r
+++ b/Imp_Scripts/DiffAnalysisHiChIP.r
@@ -491,7 +491,7 @@ FillFeatureValues <- function(UnionLoopFile, AllLoopList, BinSize, ChIPCovFileLi
 			# check the first field of chromosome name
 			# and second and third fields as integers
 			# extract the bin number and the coverage information (assume 4th field)
-			system(paste0("awk -v b=", BinSize, " \'{if (($1==\"", chrName, "\") && ($2 ~ /^[0-9]+$/) && ($3 ~ /^[0-9]+$/)) {print ($2/b)\"\t\"$4}}\' ", currcovfile, " > ", InpTempChIPCoverageFile))
+			system(paste0("awk -v b=", BinSize, " \'{if (($1==\"", chrName, "\") && ($2 ~ /^[0-9]+$/) && ($3 ~ /^[0-9]+$/)) {print ($2/b)\"\t\"$4\"\t\"$5}}\' ", currcovfile, " > ", InpTempChIPCoverageFile))
 
 			# read the ChIP coverage for the current sample and for the current chromosome
 			# ChIPCoverageData <- read.table(InpTempChIPCoverageFile, header=F, sep="\t", stringsAsFactors=F)


### PR DESCRIPTION
The file containing ChIP coverage data does not include the label information, only the coverage values, when trying to append the label it just copies the last column and as a result the labels are all coverage values rather than ND,LD,HD. Appending column 5 to the awk output fixes the problem